### PR TITLE
Update current month when value will be updated.

### DIFF
--- a/lib/src/widgets/calendar_date_picker2.dart
+++ b/lib/src/widgets/calendar_date_picker2.dart
@@ -104,6 +104,10 @@ class _CalendarDatePicker2State extends State<CalendarDatePicker2> {
     if (widget.config.calendarViewMode != oldWidget.config.calendarViewMode) {
       _mode = widget.config.calendarViewMode;
     }
+    final initialDate = widget.value.isNotEmpty && widget.value[0] != null
+        ? DateTime(widget.value[0]!.year, widget.value[0]!.month)
+        : DateUtils.dateOnly(DateTime.now());
+    _currentDisplayedMonthDate = DateTime(initialDate.year, initialDate.month);
     _selectedDates = widget.value.toList();
   }
 


### PR DESCRIPTION
**Issue:** From outside action(Filters/Button) if the value has been updated then the current month/year view is not being updated. It's showing the previously selected view only.

**e.g:** The initial `value` is: [13th April 2023]. By applying a filter let's say Last month using a button, I am updating `value` to [1st March 2023, 31th March 2023]. So Date has been selected in that range but the visible month is April. It must be changed to March.

**Fixed by:**  Fixed by updating `_currentDisplayedMonthDate` with updated `value` in `didUpdateWidget()`.